### PR TITLE
Add helpers for Docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+APP_NAME?=project-frontend
+
+_GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+_GIT_HASH=$(shell git rev-parse --short HEAD)
+_GIT_PREFIX=${_GIT_BRANCH}_${_GIT_HASH}
+
+TIME?=$(shell date +%s)
+# "L" prefix here refers to "local" to explicitly differentiate local builds from future
+# automated/CI builds
+BUILD_STRING?=L${TIME}
+
+DOCKER_TAG?=${_GIT_PREFIX}_${BUILD_STRING}
+
+_DC_FLAGS=
+DC_EXTRA_FLAGS?=
+DC_FLAGS?=${_DC_FLAGS} ${DC_EXTRA_FLAGS}
+
+
+default: image
+
+.PHONY: image
+image:
+	docker-compose -f ./compose.build.yaml up -d npm-cache
+	PROJECT_FRONTEND_TAG=${DOCKER_TAG} docker-compose -f ./compose.build.yaml build ${DC_FLAGS} project-frontend

--- a/compose.build.yaml
+++ b/compose.build.yaml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  npm-cache:
+    image: verdaccio/verdaccio
+    volumes:
+      - npm-cache-volume:/verdaccio/storage
+    network_mode: host
+
+  project-frontend:
+    extends:
+      file: compose.yaml
+      service: project-frontend
+    build:
+      network: host
+      args:
+        NPM_REGISTRY: http://localhost:4873
+
+volumes:
+  npm-cache-volume:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  project-frontend:
+    image: project-frontend:${PROJECT_FRONTEND_TAG:-latest}
+    build:
+      context: ./
+      tags:
+        - "project-frontend:latest"
+    ports:
+      - '3000:3000'


### PR DESCRIPTION
Add compose files and a Makefile that enable the following:

- Building the webapp using an `npm` cache server. This serves to speed up builds and prevent unnecessary downloads

- Auto-tagging built docker images with VCS revision information in the format of <GIT_BRANCH>_<GIT_HASH>_L<UNIX_EPOCH_TIME>. This helps to distinguish between and organize image builds.